### PR TITLE
♻️ Respect prettier default config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,12 +1,12 @@
 {
   extends: [
-    'config:base',
-    ':disableRateLimiting',
-    ':maintainLockFilesWeekly',
-    ':automergeAll',
-    'group:nodeJs',
-    'helpers:pinGitHubActionDigests',
+    "config:base",
+    ":disableRateLimiting",
+    ":maintainLockFilesWeekly",
+    ":automergeAll",
+    "group:nodeJs",
+    "helpers:pinGitHubActionDigests",
   ],
-  timezone: 'Asia/Tokyo',
-  postUpdateOptions: ['yarnDedupeHighest'],
+  timezone: "Asia/Tokyo",
+  postUpdateOptions: ["yarnDedupeHighest"],
 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3
         with:
-          node-version-file: '.node-version'
-          cache: 'yarn'
+          node-version-file: ".node-version"
+          cache: "yarn"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 10 * *' # at AM 9 JST on day of month 10
+    - cron: "0 0 10 * *" # at AM 9 JST on day of month 10
 
 concurrency:
   group: ${{ github.workflow }}
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3
         with:
-          node-version-file: '.node-version'
-          cache: 'yarn'
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: ".node-version"
+          cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,1 +1,1 @@
-module.exports = require('./index')
+module.exports = require("./index");

--- a/index.js
+++ b/index.js
@@ -1,11 +1,3 @@
 module.exports = {
-  arrowParens: 'always',
-  bracketSpacing: true,
-  embeddedLanguageFormatting: 'auto',
-  htmlWhitespaceSensitivity: 'css',
   printWidth: 100,
-  semi: false,
-  singleQuote: true,
-  tabWidth: 2,
-  trailingComma: 'all',
-}
+};


### PR DESCRIPTION
Use prettier's default config for the following reason:

- Embrace Prettier's zero-config philosophy
    - Using the default settings could reduce differences with the source code of other OSS using Prettier, possibly making it easier for new members to get accustomed to the code.
- Avoid bikeshedding
- Motivation for changing singleQuote from true to false:
    - At present, strings in JSX are double quote while others are single quote, leading to a mix.
    - Switching to double quote can unify all strings to double quote.
- Motivation for changing semi from false to true:
    - There are cases where Eslint's rules and Prettier's rules conflict when writing IIFEs.